### PR TITLE
Fix a typo

### DIFF
--- a/genai_stack/etl/run.py
+++ b/genai_stack/etl/run.py
@@ -1,17 +1,17 @@
-from genai_stack.constants.etl.etl import PREBUILT_ETL_LOADERS, ETL_MODULE
+from genai_stack.constants.etl.etl import AVAILABLE_ETL_LOADERS, ETL_MODULE
 from genai_stack.utils.importing import import_class
 
 from genai_stack.core import ConfigLoader
 
 
 def list_etl_loaders():
-    return PREBUILT_ETL_LOADERS.keys()
+    return AVAILABLE_ETL_LOADERS.keys()
 
 
 def run_etl_loader(config_file: str, vectordb):
     config_cls = ConfigLoader(name="EtlLoader", config=config_file)
     etl_cls = import_class(
-        f"{ETL_MODULE}.{PREBUILT_ETL_LOADERS.get(config_cls.config.get('etl'))}".replace(
+        f"{ETL_MODULE}.{AVAILABLE_ETL_LOADERS.get(config_cls.config.get('etl'))}".replace(
             "/",
             ".",
         )


### PR DESCRIPTION
Fixes a typo in `genai_stack/etl/run.py` file; Renames PREBUILT_ETL_LOADERS to AVAILABLE_ETL_LOADERS. Which mostly occurs when using CLI commands.